### PR TITLE
Feature/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,17 @@ Console.WriteLine(malfoy.Name); // Prints "Malfoy"
 Console.WriteLine(malfoy.House); // Prints "Slytherin"
 ```
 
+## How it works
+The resulting type `T` is constructed via the following steps:
+
+1. Find appropriate^+^ constructor _C_ for type `T`
+2. Resolve arguments _A~C~_
+2. Invoke _C_, exchanging the argument to be swapped
+2. Call property setters, exchanging the argument to be swapped
+
+^+^ The constructor taking the most arguments. If there is no constructor, the default constructor is called.
+
+In step 2, if the constructor _C_ takes the argument to be swapped, the 
+
 ## Convention
 Typesafe.With relies on the convention that the property is named the same in the type constructor.

--- a/src/Typesafe.Merge.Tests/Typesafe.Merge.Tests.cs
+++ b/src/Typesafe.Merge.Tests/Typesafe.Merge.Tests.cs
@@ -67,11 +67,11 @@ namespace Typesafe.Merge.Tests
                     yield return new object[] {0u, 1u, 1u};
                     yield return new object[] {0ul, 1ul, 1ul};
                     yield return new object[] {0L, 1L, 1L};
-//                yield return new object[] {0M, 1M, 1M};
+                    yield return new object[] {0M, 1M, 1M};
                     yield return new object[] {0d, 1d, 1d};
                     yield return new object[] {0f, 1f, 1f};
                     yield return new object[] {false, true, true};
-//                yield return new object[] {"Hello", "World", "World"};
+                    yield return new object[] {"Hello", "World", "World"};
                     yield return new object[] {'a', 'b', 'b'};
                     yield return new object[] {(byte) 0, (byte) 1, (byte) 1};
                 }

--- a/src/Typesafe.Merge.Tests/Typesafe.Merge.Tests.csproj
+++ b/src/Typesafe.Merge.Tests/Typesafe.Merge.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 

--- a/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
+++ b/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
@@ -241,6 +241,29 @@ namespace Typesafe.With.Tests
                 result.Fullname.Should().Be("NewValue1");
                 result.FullName.Should().Be("NewValue2");
             }
+            
+            internal class TypeWithDifferentCasingInConstructor
+            {
+                public string SSN { get; }
+
+                public TypeWithDifferentCasingInConstructor(string ssn)
+                {
+                    SSN = ssn;
+                }
+            }
+        
+            [Fact]
+            public void Can_set_property_which_has_different_casing_in_the_constructor()
+            {
+                // Arrange
+                var source = new TypeWithDifferentCasingInConstructor(ssn: "Some value");
+            
+                // Act
+                var result = source.With(_ => _.SSN, "New value");
+
+                // Assert
+                result.SSN.Should().Be("New value", because: "the property is set via constructor");
+            }
         }
         
         [Theory]

--- a/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
+++ b/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using AutoFixture;
 using FluentAssertions;
 using Xunit;
 
@@ -34,6 +35,11 @@ namespace Typesafe.With.Tests
         public T Value { get; set; }
     }
 
+    public class TestBase
+    {
+        protected readonly Fixture Fixture = new Fixture();
+    }
+    
     public class Tests
     {
         public class PropertyCopy
@@ -166,7 +172,7 @@ namespace Typesafe.With.Tests
 
         }
 
-        public class General
+        public class General : TestBase
         {
             private class TypeWithoutWritableProperty
             {
@@ -178,9 +184,10 @@ namespace Typesafe.With.Tests
             {
                 // Arrange
                 var source = new TypeWithoutWritableProperty();
+                var newValue = Fixture.Create<string>();
                 
                 // Act
-                Func<TypeWithoutWritableProperty> act = () => source.With(s => s.Text, "Text");
+                Func<TypeWithoutWritableProperty> act = () => source.With(s => s.Text, newValue);
                 
                 // Assert
                 act.Should()
@@ -189,11 +196,11 @@ namespace Typesafe.With.Tests
                     .And.Message.Should().Contain(nameof(TypeWithoutWritableProperty.Text));
             }
             
-            private class TypeWithNoMatchingConstructorArgument
+            private class TypeWithoutMatchingConstructorArgument
             {
                 public string FullName { get; }
 
-                public TypeWithNoMatchingConstructorArgument(string name)
+                public TypeWithoutMatchingConstructorArgument(string name)
                 {
                     FullName = name;
                 }
@@ -203,19 +210,176 @@ namespace Typesafe.With.Tests
             public void With_fails_if_property_has_no_matching_constructor_argument()
             {
                 // Arrange
-                var source = new TypeWithNoMatchingConstructorArgument(name: "Some value");
+                var source = Fixture.Create<TypeWithoutMatchingConstructorArgument>();
+                var newValue = Fixture.Create<string>();
             
                 // Act
-                Action act = () => source.With(_ => _.FullName, "New value");
+                Action act = () => source.With(_ => _.FullName, newValue);
 
                 // Assert
                 act.Should()
-                    .Throw<Exception>(because: $"there is no matching constructor parameter for property '{nameof(TypeWithNoMatchingConstructorArgument.FullName)}'")
+                    .Throw<Exception>(because: $"there is no matching constructor parameter for property '{nameof(TypeWithoutMatchingConstructorArgument.FullName)}'")
                     .WithMessage("Property '*' cannot be set via constructor or property setter.");
+            }
+            
+            [Theory]
+            [MemberData(nameof(With_works_with_any_type_Data))]
+            public void With_works_with_any_type<T>(T sourceValue, T withValue, T expectedValue)
+            {
+                // Arrange
+                var source = new Container<T> {Value = sourceValue};
+            
+                // Act
+                var result = source.With(_ => _.Value, withValue);
+            
+                // Assert
+                result.Should().BeOfType<Container<T>>();
+                result.Value.Should().Be(expectedValue);
+            }
+
+            // ReSharper disable once InconsistentNaming
+            public static IEnumerable<object[]> With_works_with_any_type_Data
+            {
+                get
+                {
+                    yield return new object[] {0, 1, 1};
+                    yield return new object[] {(short) 0, (short) 1, (short) 1};
+                    yield return new object[] {(ushort) 0, (ushort) 1, (ushort) 1};
+                    yield return new object[] {0u, 1u, 1u};
+                    yield return new object[] {0ul, 1ul, 1ul};
+                    yield return new object[] {0L, 1L, 1L};
+                    yield return new object[] {0M, 1M, 1M};
+                    yield return new object[] {0d, 1d, 1d};
+                    yield return new object[] {0f, 1f, 1f};
+                    yield return new object[] {false, true, true};
+                    yield return new object[] {"Hello", "World", "World"};
+                    yield return new object[] {'a', 'b', 'b'};
+                    yield return new object[] {(byte) 0, (byte) 1, (byte) 1};
+                }
+            }
+            
+            [Theory]
+            [ClassData(typeof(TestData))]
+            public void Can_call_With_on_type_with_only_property_setters(
+                string sourceId, string sourceName, int? sourceAge,
+                string withId, string withName, int? withAge,
+                string expectedId, string expectedName, int? expectedAge)
+            {
+                // Arrange
+                var source = new SourceWithSetters
+                {
+                    Id = sourceId,
+                    Name = sourceName,
+                    Age = sourceAge
+                };
+                
+                // Act
+                var result = source
+                    .With(_ => _.Id, withId)
+                    .With(_ => _.Name, withName)
+                    .With(_ => _.Age, withAge);
+
+                // Assert
+                result.Should().BeOfType<SourceWithSetters>();
+                result.Age.Should().Be(expectedAge);
+                result.Id.Should().Be(expectedId);
+                result.Name.Should().Be(expectedName);
+            }
+
+            [Theory]
+            [ClassData(typeof(TestData))]
+            public void Can_call_With_on_type_with_only_constructor(
+                string sourceId, string sourceName, int? sourceAge,
+                string withId, string withName, int? withAge,
+                string expectedId, string expectedName, int? expectedAge)
+            {
+                // Arrange
+                var source = new SourceWithConstructor(sourceId, sourceName, sourceAge);
+
+                // Act
+                var result = source
+                    .With(_ => _.Id, withId)
+                    .With(_ => _.Name, withName)
+                    .With(_ => _.Age, withAge);
+
+                // Assert
+                result.Should().BeOfType<SourceWithConstructor>();
+                result.Age.Should().Be(expectedAge);
+                result.Id.Should().Be(expectedId);
+                result.Name.Should().Be(expectedName);
+            }
+
+            [Theory]
+            [ClassData(typeof(TestData))]
+            public void Can_call_With_on_type_with_both_property_setter_and_constructor(
+                string sourceId, string sourceName, int? sourceAge,
+                string withId, string withName, int? withAge,
+                string expectedId, string expectedName, int? expectedAge)
+            {
+                // Arrange
+                var source = new SourceWithMixedConstructorAndSetters(sourceId, sourceName) {Age = sourceAge};
+
+                // Act
+                var result = source
+                    .With(_ => _.Id, withId)
+                    .With(_ => _.Name, withName)
+                    .With(_ => _.Age, withAge);
+
+                // Assert
+                result.Should().BeOfType<SourceWithMixedConstructorAndSetters>();
+                result.Age.Should().Be(expectedAge);
+                result.Id.Should().Be(expectedId);
+                result.Name.Should().Be(expectedName);
+                
+            }
+
+            private class TestData : IEnumerable<object[]>
+            {
+                public IEnumerator<object[]> GetEnumerator()
+                {
+                    yield return new object[]{null, null, null, null, null, null, null, null, null};
+                    yield return new object[]{null, null, 1,    null, null, null, null, null, null};
+                    yield return new object[]{null, "1",  null, null, null, null, null, null, null};
+                    yield return new object[]{null, "1",  1,    null, null, null, null, null, null};
+                    yield return new object[]{"1",  null, null, null, null, null, null, null, null};
+                    yield return new object[]{"1",  null, 1,    null, null, null, null, null, null};
+                    yield return new object[]{"1",  "1",  null, null, null, null, null, null, null};
+                    yield return new object[]{"1",  "1",  1,    null, null, null, null, null, null};
+                    yield return new object[]{null, null, null, null, null, 2,    null, null, 2};
+                    yield return new object[]{null, null, null, null, "2",  null, null, "2",  null};
+                    yield return new object[]{null, null, null, null, "2",  2,    null, "2",  2};
+                    yield return new object[]{null, null, null, "2",  null, null, "2",  null, null};
+                    yield return new object[]{null, null, null, "2",  null, 2,    "2",  null, 2};
+                    yield return new object[]{null, null, null, "2",  "2",  null, "2",  "2",  null};
+                    yield return new object[]{null, null, null, "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{null, null, 1,    null, null, 2,    null, null, 2};
+                    yield return new object[]{null, "1",  null, null, "2",  null, null, "2",  null};
+                    yield return new object[]{null, "1",  1,    null, "2",  2,    null, "2",  2};
+                    yield return new object[]{"1",  null, null, "2",  null, null, "2",  null, null};
+                    yield return new object[]{"1",  null, 1,    "2",  null, 2,    "2",  null, 2};
+                    yield return new object[]{"1",  "1",  1,    "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{"1",  "1",  1,    null, null, null, null, null, null};
+                    yield return new object[]{"1",  "1",  1,    null, null, 2,    null, null, 2};
+                    yield return new object[]{"1",  "1",  1,    null, "2",  null, null, "2",  null};
+                    yield return new object[]{"1",  "1",  1,    null, "2",  2,    null, "2",  2};
+                    yield return new object[]{"1",  "1",  1,    "2",  null, null, "2",  null, null};
+                    yield return new object[]{"1",  "1",  1,    "2",  null, 2,    "2",  null, 2};
+                    yield return new object[]{"1",  "1",  1,    "2",  "2",  null, "2",  "2",  null};
+                    yield return new object[]{"1",  "1",  1,    "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{null, null, null, "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{null, null, 1,    "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{null, "1", null,  "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{null, "1", 1,     "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{"1",  null, null, "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{"1",  null, 1,    "2",  "2",  2,    "2",  "2",  2};
+                    yield return new object[]{"1",  "1",  null, "2",  "2",  2,    "2",  "2",  2};
+                }
+
+                IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
             }
         }
 
-        public class Casing
+        public class Casing : TestBase
         {
             private class TypeWithPropertiesHavingSameNameButDifferentCasing
             {
@@ -229,20 +393,22 @@ namespace Typesafe.With.Tests
             public void Correctly_set_properties_with_same_name_but_different_casing()
             {
                 // Arrange
-                var source = new TypeWithPropertiesHavingSameNameButDifferentCasing(fullname: "Value1", fullName: "Value2");
+                var source = Fixture.Create<TypeWithPropertiesHavingSameNameButDifferentCasing>();
+                var newFullname = Fixture.Create<string>();
+                var newFullName = Fixture.Create<string>();
             
                 // Act
                 var result = source
-                    .With(_ => _.Fullname, "NewValue1")
-                    .With(_ => _.FullName, "NewValue2");
+                    .With(_ => _.Fullname, newFullname)
+                    .With(_ => _.FullName, newFullName);
             
                 // Assert
                 result.Should().NotBeNull();
-                result.Fullname.Should().Be("NewValue1");
-                result.FullName.Should().Be("NewValue2");
+                result.Fullname.Should().Be(newFullname);
+                result.FullName.Should().Be(newFullName);
             }
-            
-            internal class TypeWithDifferentCasingInConstructor
+
+            private class TypeWithDifferentCasingInConstructor
             {
                 public string SSN { get; }
 
@@ -256,183 +422,29 @@ namespace Typesafe.With.Tests
             public void Can_set_property_which_has_different_casing_in_the_constructor()
             {
                 // Arrange
-                var source = new TypeWithDifferentCasingInConstructor(ssn: "Some value");
-            
+                var source = Fixture.Create<TypeWithDifferentCasingInConstructor>();
+                var newValue = Fixture.Create<string>();
+                
                 // Act
-                var result = source.With(_ => _.SSN, "New value");
+                var result = source.With(_ => _.SSN, newValue);
 
                 // Assert
-                result.SSN.Should().Be("New value", because: "the property is set via constructor");
+                result.SSN.Should().Be(newValue, because: "the property is set via constructor");
             }
-        }
-        
-        [Theory]
-        [MemberData(nameof(With_works_with_any_type_Data))]
-        public void With_works_with_any_type<T>(T sourceValue, T withValue, T expectedValue)
-        {
-            // Arrange
-            var source = new Container<T> {Value = sourceValue};
             
-            // Act
-            var result = source.With(_ => _.Value, withValue);
-            
-            // Assert
-            result.Should().BeOfType<Container<T>>();
-            result.Value.Should().Be(expectedValue);
-        }
-
-        // ReSharper disable once InconsistentNaming
-        public static IEnumerable<object[]> With_works_with_any_type_Data
-        {
-            get
+            [Fact]
+            public void Calling_With_creates_a_new_instance()
             {
-                yield return new object[] {0, 1, 1};
-                yield return new object[] {(short) 0, (short) 1, (short) 1};
-                yield return new object[] {(ushort) 0, (ushort) 1, (ushort) 1};
-                yield return new object[] {0u, 1u, 1u};
-                yield return new object[] {0ul, 1ul, 1ul};
-                yield return new object[] {0L, 1L, 1L};
-                yield return new object[] {0M, 1M, 1M};
-                yield return new object[] {0d, 1d, 1d};
-                yield return new object[] {0f, 1f, 1f};
-                yield return new object[] {false, true, true};
-                yield return new object[] {"Hello", "World", "World"};
-                yield return new object[] {'a', 'b', 'b'};
-                yield return new object[] {(byte) 0, (byte) 1, (byte) 1};
-            }
-        }
-        
-        [Fact]
-        public void Calling_With_creates_a_new_instance()
-        {
-            // Arrange
-            var source = new SourceWithSetters();
+                // Arrange
+                var source = Fixture.Create<SourceWithSetters>();
+                var newValue = Fixture.Create<string>();
                 
-            // Act
-            var result = source.With(s => s.Id, "T");
+                // Act
+                var result = source.With(s => s.Id, newValue);
 
-            // Assert
-            result.GetHashCode().Should().NotBe(source.GetHashCode());
-        }
-
-        [Theory]
-        [ClassData(typeof(TestData))]
-        public void Can_call_With_on_type_with_only_property_setters(
-            string sourceId, string sourceName, int? sourceAge,
-            string withId, string withName, int? withAge,
-            string expectedId, string expectedName, int? expectedAge)
-        {
-            // Arrange
-            var source = new SourceWithSetters
-            {
-                Id = sourceId,
-                Name = sourceName,
-                Age = sourceAge
-            };
-            
-            // Act
-            var result = source
-                .With(_ => _.Id, withId)
-                .With(_ => _.Name, withName)
-                .With(_ => _.Age, withAge);
-
-            // Assert
-            result.Should().BeOfType<SourceWithSetters>();
-            result.Age.Should().Be(expectedAge);
-            result.Id.Should().Be(expectedId);
-            result.Name.Should().Be(expectedName);
-        }
-
-        [Theory]
-        [ClassData(typeof(TestData))]
-        public void Can_call_With_on_type_with_only_constructor(
-            string sourceId, string sourceName, int? sourceAge,
-            string withId, string withName, int? withAge,
-            string expectedId, string expectedName, int? expectedAge)
-        {
-            // Arrange
-            var source = new SourceWithConstructor(sourceId, sourceName, sourceAge);
-
-            // Act
-            var result = source
-                .With(_ => _.Id, withId)
-                .With(_ => _.Name, withName)
-                .With(_ => _.Age, withAge);
-
-            // Assert
-            result.Should().BeOfType<SourceWithConstructor>();
-            result.Age.Should().Be(expectedAge);
-            result.Id.Should().Be(expectedId);
-            result.Name.Should().Be(expectedName);
-        }
-
-        [Theory]
-        [ClassData(typeof(TestData))]
-        public void Can_call_With_on_type_with_both_property_setter_and_constructor(
-            string sourceId, string sourceName, int? sourceAge,
-            string withId, string withName, int? withAge,
-            string expectedId, string expectedName, int? expectedAge)
-        {
-            // Arrange
-            var source = new SourceWithMixedConstructorAndSetters(sourceId, sourceName) {Age = sourceAge};
-
-            // Act
-            var result = source
-                .With(_ => _.Id, withId)
-                .With(_ => _.Name, withName)
-                .With(_ => _.Age, withAge);
-
-            // Assert
-            result.Should().BeOfType<SourceWithMixedConstructorAndSetters>();
-            result.Age.Should().Be(expectedAge);
-            result.Id.Should().Be(expectedId);
-            result.Name.Should().Be(expectedName);
-            
-        }
-        
-        public class TestData : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[]{null, null, null, null, null, null, null, null, null};
-                yield return new object[]{null, null, 1,    null, null, null, null, null, null};
-                yield return new object[]{null, "1",  null, null, null, null, null, null, null};
-                yield return new object[]{null, "1",  1,    null, null, null, null, null, null};
-                yield return new object[]{"1",  null, null, null, null, null, null, null, null};
-                yield return new object[]{"1",  null, 1,    null, null, null, null, null, null};
-                yield return new object[]{"1",  "1",  null, null, null, null, null, null, null};
-                yield return new object[]{"1",  "1",  1,    null, null, null, null, null, null};
-                yield return new object[]{null, null, null, null, null, 2,    null, null, 2};
-                yield return new object[]{null, null, null, null, "2",  null, null, "2",  null};
-                yield return new object[]{null, null, null, null, "2",  2,    null, "2",  2};
-                yield return new object[]{null, null, null, "2",  null, null, "2",  null, null};
-                yield return new object[]{null, null, null, "2",  null, 2,    "2",  null, 2};
-                yield return new object[]{null, null, null, "2",  "2",  null, "2",  "2",  null};
-                yield return new object[]{null, null, null, "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{null, null, 1,    null, null, 2,    null, null, 2};
-                yield return new object[]{null, "1",  null, null, "2",  null, null, "2",  null};
-                yield return new object[]{null, "1",  1,    null, "2",  2,    null, "2",  2};
-                yield return new object[]{"1",  null, null, "2",  null, null, "2",  null, null};
-                yield return new object[]{"1",  null, 1,    "2",  null, 2,    "2",  null, 2};
-                yield return new object[]{"1",  "1",  1,    "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{"1",  "1",  1,    null, null, null, null, null, null};
-                yield return new object[]{"1",  "1",  1,    null, null, 2,    null, null, 2};
-                yield return new object[]{"1",  "1",  1,    null, "2",  null, null, "2",  null};
-                yield return new object[]{"1",  "1",  1,    null, "2",  2,    null, "2",  2};
-                yield return new object[]{"1",  "1",  1,    "2",  null, null, "2",  null, null};
-                yield return new object[]{"1",  "1",  1,    "2",  null, 2,    "2",  null, 2};
-                yield return new object[]{"1",  "1",  1,    "2",  "2",  null, "2",  "2",  null};
-                yield return new object[]{"1",  "1",  1,    "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{null, null, null, "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{null, null, 1,    "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{null, "1", null,  "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{null, "1", 1,     "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{"1",  null, null, "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{"1",  null, 1,    "2",  "2",  2,    "2",  "2",  2};
-                yield return new object[]{"1",  "1",  null, "2",  "2",  2,    "2",  "2",  2};
+                // Assert
+                result.GetHashCode().Should().NotBe(source.GetHashCode());
             }
-
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }

--- a/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
+++ b/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
@@ -187,6 +187,31 @@ namespace Typesafe.With.Tests
                     .Throw<InvalidOperationException>(
                         because: $"the property '{nameof(TypeWithoutWritableProperty.Text)}' is not writable")
                     .And.Message.Should().Contain(nameof(TypeWithoutWritableProperty.Text));
+            }
+            
+            private class TypeWithNoMatchingConstructorArgument
+            {
+                public string FullName { get; }
+
+                public TypeWithNoMatchingConstructorArgument(string name)
+                {
+                    FullName = name;
+                }
+            }
+        
+            [Fact]
+            public void With_fails_if_property_has_no_matching_constructor_argument()
+            {
+                // Arrange
+                var source = new TypeWithNoMatchingConstructorArgument(name: "Some value");
+            
+                // Act
+                Action act = () => source.With(_ => _.FullName, "New value");
+
+                // Assert
+                act.Should()
+                    .Throw<Exception>(because: $"there is no matching constructor parameter for property '{nameof(TypeWithNoMatchingConstructorArgument.FullName)}'")
+                    .WithMessage("Property '*' cannot be set via constructor or property setter.");
             }
         }
         

--- a/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
+++ b/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
@@ -292,11 +292,11 @@ namespace Typesafe.With.Tests
                 yield return new object[] {0u, 1u, 1u};
                 yield return new object[] {0ul, 1ul, 1ul};
                 yield return new object[] {0L, 1L, 1L};
-//                yield return new object[] {0M, 1M, 1M};
+                yield return new object[] {0M, 1M, 1M};
                 yield return new object[] {0d, 1d, 1d};
                 yield return new object[] {0f, 1f, 1f};
                 yield return new object[] {false, true, true};
-//                yield return new object[] {"Hello", "World", "World"};
+                yield return new object[] {"Hello", "World", "World"};
                 yield return new object[] {'a', 'b', 'b'};
                 yield return new object[] {(byte) 0, (byte) 1, (byte) 1};
             }

--- a/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
+++ b/src/Typesafe.With.Tests/Typesafe.With.Tests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
@@ -212,6 +212,34 @@ namespace Typesafe.With.Tests
                 act.Should()
                     .Throw<Exception>(because: $"there is no matching constructor parameter for property '{nameof(TypeWithNoMatchingConstructorArgument.FullName)}'")
                     .WithMessage("Property '*' cannot be set via constructor or property setter.");
+            }
+        }
+
+        public class Casing
+        {
+            private class TypeWithPropertiesHavingSameNameButDifferentCasing
+            {
+                public string Fullname { get; }
+                public string FullName { get; }
+
+                public TypeWithPropertiesHavingSameNameButDifferentCasing(string fullname, string fullName) => (Fullname, FullName) = (fullname, fullName);
+            }
+        
+            [Fact]
+            public void Correctly_set_properties_with_same_name_but_different_casing()
+            {
+                // Arrange
+                var source = new TypeWithPropertiesHavingSameNameButDifferentCasing(fullname: "Value1", fullName: "Value2");
+            
+                // Act
+                var result = source
+                    .With(_ => _.Fullname, "NewValue1")
+                    .With(_ => _.FullName, "NewValue2");
+            
+                // Assert
+                result.Should().NotBeNull();
+                result.Fullname.Should().Be("NewValue1");
+                result.FullName.Should().Be("NewValue2");
             }
         }
         

--- a/src/Typesafe.With.Tests/Typesafe.With.Tests.csproj
+++ b/src/Typesafe.With.Tests/Typesafe.With.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Typesafe.With.Tests/Typesafe.With.Tests.csproj
+++ b/src/Typesafe.With.Tests/Typesafe.With.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 

--- a/src/Typesafe.With/ObjectExtensions.cs
+++ b/src/Typesafe.With/ObjectExtensions.cs
@@ -30,18 +30,31 @@ namespace Typesafe.With
         private static void Validate<T>(string propertyName)
         {
             // Can we set the property via constructor?
-            var hasConstructorParameter = TypeUtils.GetSuitableConstructor<T>()
-                .GetParameters()
-                .Select(info => info.Name)
-                .Contains(propertyName);
+            var hasConstructorParameter = HasConstructorParameter<T>(propertyName);
             
             if (hasConstructorParameter) return;
             
             // Can we set the property via property setter?
-            if (TypeUtils.GetPropertyDictionary<T>().TryGetValue(propertyName, out var propertyInfo) && propertyInfo.CanWrite) return;
+            var hasPropertySetter = HasPropertySetter<T>(propertyName);
+            
+            if (hasPropertySetter) return;
 
             // If we cannot do either, then there is no point in continuing.
             throw new InvalidOperationException($"Property '{propertyName.ToPropertyCase()}' cannot be set via constructor or property setter.");
+        }
+
+        private static bool HasPropertySetter<T>(string propertyName)
+        {
+            return TypeUtils.GetPropertyDictionary<T>().TryGetValue(propertyName, out var propertyInfo) && propertyInfo.CanWrite;
+        }
+
+        private static bool HasConstructorParameter<T>(string propertyName)
+        {
+            // Can we find a matching constructor parameter?
+            return TypeUtils.GetSuitableConstructor<T>()
+                .GetParameters()
+                .Select(info => info.Name)
+                .Contains(propertyName);
         }
     }
 }

--- a/src/Typesafe.With/ObjectExtensions.cs
+++ b/src/Typesafe.With/ObjectExtensions.cs
@@ -50,11 +50,21 @@ namespace Typesafe.With
 
         private static bool HasConstructorParameter<T>(string propertyName)
         {
+            var constructorParameters = TypeUtils.GetSuitableConstructor<T>().GetParameters();
+            
             // Can we find a matching constructor parameter?
-            return TypeUtils.GetSuitableConstructor<T>()
-                .GetParameters()
-                .Select(info => info.Name)
-                .Contains(propertyName);
+            var hasConstructorParameter = constructorParameters
+                .Any(info => string.Equals(info.Name, propertyName, StringComparison.Ordinal));
+            
+            if (hasConstructorParameter) return true;
+
+            // Can we find a matching constructor parameter if we lowercase both parameter and property name?
+            var hasConstructorParameterByLowercase = constructorParameters
+                .Any(info => string.Equals(info.Name, propertyName, StringComparison.InvariantCultureIgnoreCase));
+
+            if (hasConstructorParameterByLowercase) return true;
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Add support for constructor argument having a different casing than the property

This is mainly to support scenarios in which the property name is an acronym e.g. SSN, HTTP, FTP.

Example:
```
class Person
{
    public string SSN { get; }

    public Person(string ssn)
    {
        SSN = ssn;
    }
}

var person = new Person("XXX");
var personWithSSN = person.With(p => p.SSN, "YYY");
```